### PR TITLE
Replace site icon and favicon with new logo image

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <title>SideInstaller — Install</title>
+<link rel="icon" href="https://files.catbox.moe/gi0g5w.png">
+<link rel="apple-touch-icon" href="https://files.catbox.moe/gi0g5w.png">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="color-scheme" content="dark">
 <meta name="theme-color" content="#0a0a0f">
@@ -146,7 +148,7 @@
 <div class="wrap">
 
   <header class="hero">
-    <div class="logo"><svg viewBox="0 0 24 24" fill="none" stroke="url(#g)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><defs><linearGradient id="g" x1="0" y1="0" x2="24" y2="24"><stop offset="0" stop-color="#6d8bff"/><stop offset="1" stop-color="#a06bff"/></linearGradient></defs><rect x="4" y="2.5" width="16" height="19" rx="3.5"/><path d="M12 7v8"/><path d="M8.5 11.5L12 15l3.5-3.5"/></svg></div>
+    <div class="logo"><img src="https://files.catbox.moe/gi0g5w.png" alt="SideInstaller"></div>
     <h1>SideInstaller</h1>
     <p class="tagline">On-device sideloader. Pick a certificate and tap install.</p>
     <div class="badges">


### PR DESCRIPTION
## What changed
- Added a browser-tab favicon (`<link rel="icon">` plus `apple-touch-icon`) pointing to the new logo PNG.
- Replaced the inline SVG inside `.logo` with an `<img>` of the new logo. Existing `.logo img` CSS handles sizing.

## Why
Update the site to use the new SideInstaller logo image for both the tab icon and the on-page logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)